### PR TITLE
Amazon Linux Version

### DIFF
--- a/php/compiler.Dockerfile
+++ b/php/compiler.Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2018.03
+FROM amazonlinux:latest
 
 WORKDIR /tmp
 


### PR DESCRIPTION
Is there a reason the latest tag of AWS Linux AMI is not being used?

If you don't want to version then use the `amazonlinux:2` over the `amazonlinux:2018.03`

Version 2 has long life support and is kernel level optimized for AWS hypervisors.