### PR TITLE
Use lambci/lambda:provided as base Docker image.

### DIFF
--- a/php/Makefile
+++ b/php/Makefile
@@ -12,5 +12,6 @@ distribution: build
 		--volume ${PWD}/runtime:/runtime:ro \
 		--volume ${PWD}/../export:/export \
 		--volume ${PWD}/export.sh:/export.sh:ro \
+		--user root \
+		--entrypoint /export.sh \
 		vapor/runtime/php-73:latest \
-		/export.sh

--- a/php/php.Dockerfile
+++ b/php/php.Dockerfile
@@ -409,17 +409,14 @@ RUN /opt/bin/php -i | grep curl
 
 # Copy Everything To The Base Container
 
-FROM amazonlinux:2018.03
+FROM lambci/lambda:provided
 
 ENV INSTALL_DIR="/opt/vapor"
 
 ENV PATH="/opt/bin:${PATH}" \
     LD_LIBRARY_PATH="${INSTALL_DIR}/lib64:${INSTALL_DIR}/lib"
 
-RUN mkdir -p /opt
-
-WORKDIR /opt
+WORKDIR /var/task
 
 COPY --from=php_builder /opt /opt
-
-RUN LD_LIBRARY_PATH= yum -y install zip
+COPY --from=php_builder /usr/bin/zip /usr/bin/zip


### PR DESCRIPTION
This PR modifies the Docker image used by `vapor local` and `vapor test` commands to use `lambci/lambda:provided` as a base (https://hub.docker.com/r/lambci/lambda/). This image more accurately emulates the Lambda container environment than the `amazonlinux:2018.03` image that is currently used as a base.

I have a project that relies on native binaries such as wkhtmltopdf, jpegoptim, and optipng that I have compiled to run in the Lambda container environment and included in my project files (Would love to see Vapor support user provided layers :grimacing:). I also have logic to conditionally make use of these binaries when it is detected that the application is running in a Lambda container (based on the presence of `LAMBDA_TASK_ROOT` environment variable). 

My compiled binaries run fine on Lambda and in the `lambci/lambda:provided` container however I receive dependency related errors when I try to execute the binaries in the current `vapor/runtime/php-73:latest` image. Also, `vapor test` currently lacks the ability to set environment variables such as `LAMBDA_TASK_ROOT` which are included with the `lambci/lambda:provided` image.

As such, `vapor test` is currently insufficient to run my test suite.  I've been successfully executing my tests using an image built with these changes via `docker run --rm --entrypoint ./vendor/bin/phpunit -v "$PWD":/var/task vapor/runtime/php-73:latest`.

If this PR is merged the local command will need to be updated to mount the project directory to `/var/task` instead of `/app`.