### PR TITLE
Enable sockets for sending X-RAY data over UDP 

### DIFF
--- a/php73/php.Dockerfile
+++ b/php73/php.Dockerfile
@@ -358,6 +358,7 @@ RUN set -xe \
         --with-zlib-dir=${INSTALL_DIR} \
         --with-curl=${INSTALL_DIR} \
         --enable-bcmath \
+        --enable-sockets \
         --enable-exif \
         --enable-ftp \
         --with-gettext \

--- a/php74/php.Dockerfile
+++ b/php74/php.Dockerfile
@@ -379,6 +379,7 @@ RUN set -xe \
         --with-zlib=${INSTALL_DIR} \
         --with-curl \
         --enable-bcmath \
+        --enable-sockets \
         --enable-exif \
         --enable-ftp \
         --with-gettext \


### PR DESCRIPTION
Could we please enable sockets. 

The X-Ray Daemon needs to receive the tracing data over UDP. see https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html
