### PR TITLE
Adds possibility of using AL2 with separate vendor option

### DIFF
--- a/awscli/Makefile
+++ b/awscli/Makefile
@@ -1,0 +1,12 @@
+SHELL := /bin/bash
+
+build: awscli.Dockerfile
+	docker build -f ${PWD}/awscli.Dockerfile -t vapor/runtime/awscli:latest .
+
+distribution: build
+	docker run --rm \
+		--volume ${PWD}/runtime:/runtime:ro \
+		--volume ${PWD}/../export:/export \
+		--volume ${PWD}/export.sh:/export.sh:ro \
+		vapor/runtime/awscli:latest \
+		/export.sh

--- a/awscli/awscli.Dockerfile
+++ b/awscli/awscli.Dockerfile
@@ -1,0 +1,44 @@
+# Install AWS CLI
+
+FROM amazonlinux:latest as awsclibuilder
+
+WORKDIR /root
+
+RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+
+RUN yum update -y && yum install -y unzip
+
+RUN unzip awscli-bundle.zip && cd awscli-bundle;
+
+RUN ./awscli-bundle/install -i /opt/awscli -b /opt/awscli/aws
+
+# Copy Everything To The Base Container
+
+FROM amazonlinux:2
+
+ENV INSTALL_DIR="/opt/vapor"
+
+ENV PATH="/opt/bin:${PATH}" \
+    LD_LIBRARY_PATH="${INSTALL_DIR}/lib64:${INSTALL_DIR}/lib"
+
+RUN mkdir -p /opt
+
+WORKDIR /opt
+
+COPY --from=awsclibuilder /opt/awscli/lib/python2.7/site-packages/ /opt/awscli/
+COPY --from=awsclibuilder /opt/awscli/bin/ /opt/awscli/bin/
+COPY --from=awsclibuilder /opt/awscli/bin/aws /opt/awscli/aws
+COPY --from=awsclibuilder /usr/lib64/libpython2.7.so.* /opt/awscli/lib/
+COPY --from=awsclibuilder /usr/lib64/libpthread.so.* /opt/awscli/lib/
+COPY --from=awsclibuilder /usr/lib64/libexpat.so.* /opt/awscli/lib/
+COPY --from=awsclibuilder /usr/lib64/libdl.so.* /opt/awscli/lib/
+COPY --from=awsclibuilder /usr/lib64/libutil.so.* /opt/awscli/lib/
+COPY --from=awsclibuilder /usr/lib64/libm.so.* /opt/awscli/lib/
+COPY --from=awsclibuilder /usr/lib64/libc.so.* /opt/awscli/lib/
+COPY --from=awsclibuilder /usr/lib64/ld-linux-x86-64.so.* /opt/awscli/lib/
+COPY --from=awsclibuilder /usr/lib64/python2.7/ /opt/awscli/lib/python2.7/
+COPY --from=awsclibuilder /usr/lib64/python2.7/lib-dynload/ /opt/awscli/lib/python2.7/lib-dynload/
+
+RUN LD_LIBRARY_PATH= yum -y install zip
+
+RUN rm -rf /opt/awscli/pip* /opt/awscli/setuptools* /opt/awscli/awscli/examples

--- a/awscli/export.sh
+++ b/awscli/export.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+set -u
+set -x
+
+cd /opt
+
+ls -la
+
+zip --quiet --recurse-paths /export/awscli.zip .

--- a/php80al2/php.Dockerfile
+++ b/php80al2/php.Dockerfile
@@ -373,8 +373,9 @@ RUN set -xe; \
 
 WORKDIR  ${PHP_BUILD_DIR}/
 
-RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel sqlite-devel libxslt-devel ImageMagick-devel
+RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel sqlite-devel libxslt-devel ImageMagick-devel unzip
 
+RUN cp -a /usr/bin/unzip ${INSTALL_DIR}/bin/unzip
 RUN cp -a /usr/lib64/libgpg-error.so* ${INSTALL_DIR}/lib64/
 RUN cp -a /usr/lib64/libtinfo.so* ${INSTALL_DIR}/lib64/
 RUN cp -a /usr/lib64/libgcrypt.so* ${INSTALL_DIR}/lib64/
@@ -444,7 +445,7 @@ RUN pecl install -f redis-5.3.2
 RUN find ${INSTALL_DIR} -type f -name "*.so*" -o -name "*.a"  -exec strip --strip-unneeded {} \;
 RUN find ${INSTALL_DIR} -type f -executable -exec sh -c "file -i '{}' | grep -q 'x-executable; charset=binary'" \; -print|xargs strip --strip-all
 
-# Symlink All Binaries / Libaries
+# Symlink All Binaries / Libraries
 
 RUN mkdir -p /opt/bin
 RUN mkdir -p /opt/lib
@@ -462,40 +463,3 @@ RUN cp /opt/vapor/lib64/* /opt/lib || true
 
 RUN ls /opt/bin
 RUN /opt/bin/php -i | grep curl
-
-# Install AWS CLI
-
-FROM amazonlinux:latest as awsclibuilder
-
-WORKDIR /root
-
-RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-
-RUN yum update -y && yum install -y unzip
-
-RUN unzip awscli-bundle.zip && cd awscli-bundle;
-
-RUN ./awscli-bundle/install -i /opt/awscli -b /opt/awscli/aws
-
-
-# Copy Everything To The Base Container
-
-FROM amazonlinux:2
-
-ENV INSTALL_DIR="/opt/vapor"
-
-ENV PATH="/opt/bin:${PATH}" \
-    LD_LIBRARY_PATH="${INSTALL_DIR}/lib64:${INSTALL_DIR}/lib"
-
-RUN mkdir -p /opt
-
-WORKDIR /opt
-
-COPY --from=php_builder /opt /opt
-COPY --from=awsclibuilder /opt/awscli/lib/python2.7/site-packages/ /opt/awscli/
-COPY --from=awsclibuilder /opt/awscli/bin/ /opt/awscli/bin/
-COPY --from=awsclibuilder /opt/awscli/bin/aws /opt/awscli/aws
-
-RUN LD_LIBRARY_PATH= yum -y install zip
-
-RUN rm -rf /opt/awscli/pip* /opt/awscli/setuptools* /opt/awscli/awscli/examples

--- a/publish.php
+++ b/publish.php
@@ -15,7 +15,8 @@ $layers = [
     // 'php-80' => 'Laravel Vapor PHP 8.0 for Amazon Linux 1',
 
     // Amazon Linux 2:
-    // 'php-74al2' => 'Laravel Vapor PHP 7.4 for Amazon Linux 2',
+    'awscli' => 'AWS CLI for Amazon Linux 2',
+    'php-74al2' => 'Laravel Vapor PHP 7.4 for Amazon Linux 2',
     'php-80al2' => 'Laravel Vapor PHP 8.0 for Amazon Linux 2',
 ];
 


### PR DESCRIPTION
This pull request adds the possibility of AL2 be used with the `separate-vendor` option.

Today, when the `separate-vendor` option is used, Vapor core uses the `awscli` to get the `vendor` folder from S3. Unfortunately, to use `awscli` in AL2, that requires the installation a few dependencies that combined with the original image makes the layer goes over the 50MB ( the limit in AWS ).

Therefore, we now split the AWSCLI layer from the PHP layer.