### PR TITLE
Removes installation of AWS CLI on AL2 layers

### DIFF
--- a/php74al2/php.Dockerfile
+++ b/php74al2/php.Dockerfile
@@ -464,21 +464,6 @@ RUN cp /opt/vapor/lib64/* /opt/lib || true
 RUN ls /opt/bin
 RUN /opt/bin/php -i | grep curl
 
-# Install AWS CLI
-
-FROM amazonlinux:latest as awsclibuilder
-
-WORKDIR /root
-
-RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-
-RUN yum update -y && yum install -y unzip
-
-RUN unzip awscli-bundle.zip && cd awscli-bundle;
-
-RUN ./awscli-bundle/install -i /opt/awscli -b /opt/awscli/aws
-
-
 # Copy Everything To The Base Container
 
 FROM amazonlinux:2
@@ -493,10 +478,4 @@ RUN mkdir -p /opt
 WORKDIR /opt
 
 COPY --from=php_builder /opt /opt
-COPY --from=awsclibuilder /opt/awscli/lib/python2.7/site-packages/ /opt/awscli/
-COPY --from=awsclibuilder /opt/awscli/bin/ /opt/awscli/bin/
-COPY --from=awsclibuilder /opt/awscli/bin/aws /opt/awscli/aws
-
 RUN LD_LIBRARY_PATH= yum -y install zip
-
-RUN rm -rf /opt/awscli/pip* /opt/awscli/setuptools* /opt/awscli/awscli/examples

--- a/php80al2/php.Dockerfile
+++ b/php80al2/php.Dockerfile
@@ -463,21 +463,6 @@ RUN cp /opt/vapor/lib64/* /opt/lib || true
 RUN ls /opt/bin
 RUN /opt/bin/php -i | grep curl
 
-# Install AWS CLI
-
-FROM amazonlinux:latest as awsclibuilder
-
-WORKDIR /root
-
-RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-
-RUN yum update -y && yum install -y unzip
-
-RUN unzip awscli-bundle.zip && cd awscli-bundle;
-
-RUN ./awscli-bundle/install -i /opt/awscli -b /opt/awscli/aws
-
-
 # Copy Everything To The Base Container
 
 FROM amazonlinux:2
@@ -492,10 +477,4 @@ RUN mkdir -p /opt
 WORKDIR /opt
 
 COPY --from=php_builder /opt /opt
-COPY --from=awsclibuilder /opt/awscli/lib/python2.7/site-packages/ /opt/awscli/
-COPY --from=awsclibuilder /opt/awscli/bin/ /opt/awscli/bin/
-COPY --from=awsclibuilder /opt/awscli/bin/aws /opt/awscli/aws
-
 RUN LD_LIBRARY_PATH= yum -y install zip
-
-RUN rm -rf /opt/awscli/pip* /opt/awscli/setuptools* /opt/awscli/awscli/examples


### PR DESCRIPTION
This pull request performs some clean up removing the code associated with AWS CLI that is no longer used with Amazon Linux 2 layers.

Note: No actions are required in your side @taylorotwell, just merge.