### PR TITLE
Update the ca-cert link and let `curl` follow redirections so builds won't fail

### DIFF
--- a/php73/php.Dockerfile
+++ b/php73/php.Dockerfile
@@ -59,7 +59,7 @@ RUN set -xe; \
 ARG openssl
 ENV VERSION_OPENSSL=${openssl}
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
-ENV CA_BUNDLE_SOURCE="https://curl.haxx.se/ca/cacert.pem"
+ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/ssl/cert.pem"
 
 RUN set -xe; \
@@ -83,7 +83,7 @@ RUN set -xe; \
 
 RUN set -xe; \
     make install \
-    && curl -k -o ${CA_BUNDLE} ${CA_BUNDLE_SOURCE}
+    && curl -L -k -o ${CA_BUNDLE} ${CA_BUNDLE_SOURCE}
 
 # Build LibSSH2 (https://github.com/libssh2/libssh2/releases/)
 

--- a/php74/php.Dockerfile
+++ b/php74/php.Dockerfile
@@ -59,7 +59,7 @@ RUN set -xe; \
 ARG openssl
 ENV VERSION_OPENSSL=${openssl}
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
-ENV CA_BUNDLE_SOURCE="https://curl.haxx.se/ca/cacert.pem"
+ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/ssl/cert.pem"
 
 RUN set -xe; \
@@ -83,7 +83,7 @@ RUN set -xe; \
 
 RUN set -xe; \
     make install \
-    && curl -k -o ${CA_BUNDLE} ${CA_BUNDLE_SOURCE}
+    && curl -L -k -o ${CA_BUNDLE} ${CA_BUNDLE_SOURCE}
 
 # Build LibSSH2 (https://github.com/libssh2/libssh2/releases/)
 

--- a/php74al2/php.Dockerfile
+++ b/php74al2/php.Dockerfile
@@ -59,7 +59,7 @@ RUN set -xe; \
 ARG openssl
 ENV VERSION_OPENSSL=${openssl}
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
-ENV CA_BUNDLE_SOURCE="https://curl.haxx.se/ca/cacert.pem"
+ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/ssl/cert.pem"
 
 RUN set -xe; \
@@ -83,7 +83,7 @@ RUN set -xe; \
 
 RUN set -xe; \
     make install \
-    && curl -k -o ${CA_BUNDLE} ${CA_BUNDLE_SOURCE}
+    && curl -L -k -o ${CA_BUNDLE} ${CA_BUNDLE_SOURCE}
 
 # Build LibSSH2 (https://github.com/libssh2/libssh2/releases/)
 

--- a/php80/php.Dockerfile
+++ b/php80/php.Dockerfile
@@ -59,7 +59,7 @@ RUN set -xe; \
 ARG openssl
 ENV VERSION_OPENSSL=${openssl}
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
-ENV CA_BUNDLE_SOURCE="https://curl.haxx.se/ca/cacert.pem"
+ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/ssl/cert.pem"
 
 RUN set -xe; \
@@ -83,7 +83,7 @@ RUN set -xe; \
 
 RUN set -xe; \
     make install \
-    && curl -k -o ${CA_BUNDLE} ${CA_BUNDLE_SOURCE}
+    && curl -L -k -o ${CA_BUNDLE} ${CA_BUNDLE_SOURCE}
 
 # Build LibSSH2 (https://github.com/libssh2/libssh2/releases/)
 

--- a/php80al2/php.Dockerfile
+++ b/php80al2/php.Dockerfile
@@ -59,7 +59,7 @@ RUN set -xe; \
 ARG openssl
 ENV VERSION_OPENSSL=${openssl}
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
-ENV CA_BUNDLE_SOURCE="https://curl.haxx.se/ca/cacert.pem"
+ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/ssl/cert.pem"
 
 RUN set -xe; \
@@ -83,7 +83,7 @@ RUN set -xe; \
 
 RUN set -xe; \
     make install \
-    && curl -k -o ${CA_BUNDLE} ${CA_BUNDLE_SOURCE}
+    && curl -L -k -o ${CA_BUNDLE} ${CA_BUNDLE_SOURCE}
 
 # Build LibSSH2 (https://github.com/libssh2/libssh2/releases/)
 


### PR DESCRIPTION
It seems `https://curl.haxx.se/ca/cacert.pem` is now redirecting to `https://curl.se/ca/cacert.pem` and the `curl` command fetching the certificate is not following redirections. As a result, `/opt/vapor/cert.pem` ending up with the HTML response of the redirection and causing the following `curl` commands to fail.

This PR is updating the links and also adding `-L` flag to the curl command so it can follow the redirection if it happens again.

Redirection:
```bash
$ curl -I  https://curl.haxx.se/ca/cacert.pem
...
location: https://curl.se/ca/cacert.pem
...
```

What the existing link returns:
```bash
$ curl https://curl.haxx.se/ca/cacert.pem 
```
```html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://curl.se/ca/cacert.pem">here</a>.</p>
<hr>
<address>Apache Server at curl.haxx.se Port 80</address>
</body></html>
```