### PR TITLE
Disables `file_cache` on native images

### DIFF
--- a/php80al2/runtime/php.ini
+++ b/php80al2/runtime/php.ini
@@ -9,7 +9,6 @@ expose_php=off
 
 opcache.enable=1
 opcache.enable_cli=1
-opcache.file_cache="/tmp/opcache"
 
 opcache.validate_permission=0
 opcache.validate_timestamps=0

--- a/php81al2/runtime/php.ini
+++ b/php81al2/runtime/php.ini
@@ -9,7 +9,6 @@ expose_php=off
 
 opcache.enable=1
 opcache.enable_cli=1
-opcache.file_cache="/tmp/opcache"
 
 opcache.validate_permission=0
 opcache.validate_timestamps=0

--- a/php82al2/runtime/php.ini
+++ b/php82al2/runtime/php.ini
@@ -9,7 +9,6 @@ expose_php=off
 
 opcache.enable=1
 opcache.enable_cli=1
-opcache.file_cache="/tmp/opcache"
 
 opcache.validate_permission=0
 opcache.validate_timestamps=0


### PR DESCRIPTION
This pull request continues applies the same fix we've done on docker images - by disabling `file_cache` and preventing op cache behave weirdly on Serverless environments. Although, at first, we had reasons to believe that this fix was only necessary on applications bigger than our 50MB limit (docker images), if the https://github.com/googleapis/google-api-php-client is installed on applications lower than this limit, is still possible to experience the issue: `foo(): Argument #1 ($argument) must be of type string, string given` ( at least we had 1 customer facing it - so better be cautions here )

- [x] Nuno should test performance regressions.
- [ ] Joe should build `php-8.0:al2`, `php-8.1:al2`, `php-8.2:al2`, and check via `phpinfo()` that the `file_cache` gets disabled by this fix. Note that we are not applying this fix on PHP 7.4 as it's out-of-support for years now.
- [ ] Joe should publish images.